### PR TITLE
Update import `Ng2Highcharts` instruction base on 0.3.5 changes.

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -28,7 +28,7 @@ A running example on how to use this library can be found at [AngularShowcase](h
   ```
 * Import `Ng2Highcharts` in the component
   ```
-  import { Ng2Highcharts } from 'ng2-highcharts/ng2-highcharts';
+  import { Ng2Highcharts } from 'ng2-highcharts';
   ```
 * Include `Ng2Highcharts` in the directives
   ```


### PR DESCRIPTION
This fixes #28 