### PR TITLE
KeyValueDiffer requires <K, V> in 4.0.0

### DIFF
--- a/src/ng2-highcharts-base.ts
+++ b/src/ng2-highcharts-base.ts
@@ -9,7 +9,7 @@ export abstract class Ng2HighchartsBase implements OnDestroy, DoCheck {
 	pChart: any;//HighchartsChartObject;
 	currentWidth: number;
 	currentHeight: number;
-	differ: KeyValueDiffer;
+	differ: KeyValueDiffer<any, any>;
 	constructor(ele: ElementRef, _differs: KeyValueDiffers) {
 		this.hostElement = ele;
 		this.differ = _differs.find({}).create(null);


### PR DESCRIPTION
https://github.com/angular/angular/blob/bebedfed24d6fbfa492e97f071e1d1b41e411280/packages/core/src/change_detection/differs/keyvalue_differs.ts#L19

We had to make this change in order to get the typescript compiler to build ng2-highcharts for Angular 4.0.0.