### PR TITLE
fix cannot read property 'chart' of undefined error

### DIFF
--- a/src/ng2-highcharts-base.ts
+++ b/src/ng2-highcharts-base.ts
@@ -26,8 +26,10 @@ export abstract class Ng2HighchartsBase implements OnDestroy, DoCheck {
 			var duration = parseFloat(getComputedStyle(this.hostElement.nativeElement).transitionDuration);
 			var interval = setInterval(() => {
 				if (duration < 0) { clearInterval(interval); }
-				this.pChart.reflow();
 				duration -= 50;
+				if (this.pChart) {
+					this.pChart.reflow();
+				}
 			}, duration);
 		}
 


### PR DESCRIPTION
As pChart.reflow throws an exception, the duration never gets decremented so the interval runs forever. This makes sure the duration is always decremented before trying to get the chart to reflow.

Closes #75